### PR TITLE
Fix function name evaluation for dynamic spec filter

### DIFF
--- a/src/main/java/com/icthh/xm/ms/entity/domain/spec/FunctionSpec.java
+++ b/src/main/java/com/icthh/xm/ms/entity/domain/spec/FunctionSpec.java
@@ -8,6 +8,9 @@ import lombok.Data;
 import java.util.List;
 import java.util.Map;
 
+import static com.icthh.xm.ms.entity.service.impl.FunctionServiceImpl.FUNCTION_CALL_PRIV;
+import static com.icthh.xm.ms.entity.service.impl.FunctionServiceImpl.XM_ENITITY_FUNCTION_CALL_PRIV;
+
 /**
  * The {@link FunctionSpec} class.
  */
@@ -86,6 +89,12 @@ public class FunctionSpec {
 
     public Boolean getOnlyData() {
         return onlyData == null ? false : onlyData;
+    }
+
+    public String getDynamicPrivilegeKey() {
+        return getWithEntityId() ?
+            XM_ENITITY_FUNCTION_CALL_PRIV.concat(".").concat(getKey()) :
+            FUNCTION_CALL_PRIV.concat(".").concat(getKey());
     }
 
 }

--- a/src/main/java/com/icthh/xm/ms/entity/security/access/DynamicPermissionCheckService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/security/access/DynamicPermissionCheckService.java
@@ -119,6 +119,7 @@ public class DynamicPermissionCheckService {
         List<I> filteredList = Lists.newArrayList();
 
         Set<String> lPermissions = getRoleFunctionPermissions();
+
         if (!lPermissions.isEmpty()) {
             filteredList = innerGetter.get()
                                       .stream()

--- a/src/main/java/com/icthh/xm/ms/entity/service/XmEntitySpecService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/XmEntitySpecService.java
@@ -463,7 +463,7 @@ public class XmEntitySpecService implements RefreshableConfiguration {
         return dynamicPermissionCheckService.filterInnerListByPermission(spec,
             spec::getFunctions,
             spec::setFunctions,
-            FunctionSpec::getKey);
+            FunctionSpec::getDynamicPrivilegeKey);
     }
 
 }

--- a/src/main/java/com/icthh/xm/ms/entity/service/impl/FunctionServiceImpl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/impl/FunctionServiceImpl.java
@@ -36,8 +36,8 @@ public class FunctionServiceImpl implements FunctionService {
     //Function is not visible, but could be executed
     public static String NONE = "NONE";
 
-    private static String FUNCTION_CALL_PRIV = "FUNCTION.CALL";
-    private static String XM_ENITITY_FUNCTION_CALL_PRIV = "XMENTITY.FUNCTION.EXECUTE";
+    public static String FUNCTION_CALL_PRIV = "FUNCTION.CALL";
+    public static String XM_ENITITY_FUNCTION_CALL_PRIV = "XMENTITY.FUNCTION.EXECUTE";
 
     private final XmEntitySpecService xmEntitySpecService;
     private final XmEntityService xmEntityService;

--- a/src/test/java/com/icthh/xm/ms/entity/security/access/DynamicPermissionCheckServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/security/access/DynamicPermissionCheckServiceUnitTest.java
@@ -5,6 +5,8 @@ import static com.google.common.collect.Sets.newHashSet;
 import static com.icthh.xm.ms.entity.security.access.DynamicPermissionCheckService.CONFIG_SECTION;
 import static com.icthh.xm.ms.entity.security.access.DynamicPermissionCheckService.DYNAMIC_FUNCTION_PERMISSION_FEATURE;
 import static com.icthh.xm.ms.entity.security.access.DynamicPermissionCheckService.FeatureContext;
+import static com.icthh.xm.ms.entity.service.impl.FunctionServiceImpl.FUNCTION_CALL_PRIV;
+import static com.icthh.xm.ms.entity.service.impl.FunctionServiceImpl.XM_ENITITY_FUNCTION_CALL_PRIV;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -143,13 +145,13 @@ public class DynamicPermissionCheckServiceUnitTest extends AbstractUnitTest {
 
         given(tenantConfig.getConfig()).willReturn(config);
 
-        Set<String> rolesPrivileges = newHashSet("function1", "function3");
+        Set<String> rolesPrivileges = newHashSet(XM_ENITITY_FUNCTION_CALL_PRIV + ".F1", FUNCTION_CALL_PRIV + ".F3");
         given(dynamicPermissionCheckService.getRoleFunctionPermissions()).willReturn(rolesPrivileges);
 
         List<FunctionSpec> functions = newArrayList(
-            createFunction("function1"),
-            createFunction("function2"),
-            createFunction("function3")
+            createEntityFunction("F1"),
+            createFunction("F2"),
+            createFunction("F3")
         );
         TypeSpec typeSpec = new TypeSpec();
         typeSpec.setFunctions(functions);
@@ -157,16 +159,22 @@ public class DynamicPermissionCheckServiceUnitTest extends AbstractUnitTest {
         TypeSpec result = dynamicPermissionCheckService.filterInnerListByPermission(typeSpec,
                                                                                     typeSpec::getFunctions,
                                                                                     typeSpec::setFunctions,
-                                                                                    FunctionSpec::getKey);
+                                                                                    FunctionSpec::getDynamicPrivilegeKey);
 
         assertThat(result.getFunctions().stream().map(FunctionSpec::getKey))
-            .containsExactly("function1", "function3");
+            .containsExactly("F1", "F3");
 
     }
 
     private FunctionSpec createFunction(String key){
         FunctionSpec spec = new FunctionSpec();
         spec.setKey(key);
+        return spec;
+    }
+
+    private FunctionSpec createEntityFunction(String key){
+        FunctionSpec spec = createFunction(key);
+        spec.setWithEntityId(true);
         return spec;
     }
 


### PR DESCRIPTION
Spec filtering for dynamic permission should be done by spec path + funkKey.
f.e. `"FUNCTION.CALL" + "." + "FUNCTION1"`