### PR TITLE
removing of xmEntitySpecService.findTypeByKey usage in codebase

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=entity
 profile=dev
-version=2.0.17
+version=2.0.18
 
 # Build properties
 node_version=12.13.0

--- a/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
@@ -215,7 +215,8 @@ public class XmEntityServiceImpl implements XmEntityService {
             .getTypeSpecByKey(xmEntity.getTypeKey())
             .map(TypeSpec::getNamePattern)
             .filter(StringUtils::isNotEmpty)
-            .ifPresent(parentName -> xmEntity.setName(simpleTemplateProcessors.processTemplate(parentName, xmEntity)));
+            .map(parentName -> simpleTemplateProcessors.processTemplate(parentName, xmEntity))
+            .ifPresent(xmEntity::setName);
     }
 
     private void preventRenameTenant(XmEntity xmEntity, XmEntity oldEntity) {

--- a/src/main/java/com/icthh/xm/ms/entity/validator/JsonDataValidator.java
+++ b/src/main/java/com/icthh/xm/ms/entity/validator/JsonDataValidator.java
@@ -40,7 +40,7 @@ public class JsonDataValidator implements ConstraintValidator<JsonData, XmEntity
 
     @Override
     public boolean isValid(XmEntity value, ConstraintValidatorContext context) {
-        TypeSpec typeSpecification = xmEntitySpecService.findTypeByKey(value.getTypeKey());
+        TypeSpec typeSpecification = xmEntitySpecService.getTypeSpecByKey(value.getTypeKey()).orElse(null);
 
         if (!present(typeSpecification) || dataAndSpecificationEmpty(value, typeSpecification)) {
             return true;

--- a/src/main/java/com/icthh/xm/ms/entity/validator/StateKeyValidator.java
+++ b/src/main/java/com/icthh/xm/ms/entity/validator/StateKeyValidator.java
@@ -34,18 +34,14 @@ public class StateKeyValidator implements ConstraintValidator<StateKey, XmEntity
             return true;
         }
 
-        TypeSpec typeSpec = xmEntitySpecService.findTypeByKey(value.getTypeKey());
+        List<StateSpec> stateSpecs = xmEntitySpecService.getTypeSpecByKey(value.getTypeKey())
+            .map(TypeSpec::getStates)
+            .orElse(List.of());
 
-        if (typeSpec == null) {
+        if (stateSpecs.isEmpty()) {
             return true;
         }
 
-        if (isEmpty(typeSpec.getStates()) && value.getStateKey() == null) {
-            return true;
-        }
-
-        List<StateSpec> stateSpecs = typeSpec.getStates();
-        stateSpecs = (stateSpecs != null) ? stateSpecs : Collections.emptyList();
         Set<String> stateKeys = stateSpecs.stream().map(StateSpec::getKey).collect(toSet());
         log.debug("Type specification states {}, checked state {}", stateKeys, value.getStateKey());
         return stateKeys.contains(value.getStateKey());

--- a/src/main/java/com/icthh/xm/ms/entity/validator/XmEntityFieldNotNullValidator.java
+++ b/src/main/java/com/icthh/xm/ms/entity/validator/XmEntityFieldNotNullValidator.java
@@ -30,7 +30,7 @@ public class XmEntityFieldNotNullValidator implements ConstraintValidator<NotNul
     @Override
     @SneakyThrows
     public boolean isValid(XmEntity xmEntity, ConstraintValidatorContext ctx) {
-        TypeSpec typeSpec = xmEntitySpecService.findTypeByKey(xmEntity.getTypeKey());
+        TypeSpec typeSpec = xmEntitySpecService.getTypeSpecByKey(xmEntity.getTypeKey()).orElse(null);
 
         if (typeSpec == null) {
             return true;

--- a/src/test/java/com/icthh/xm/ms/entity/service/XmEntityGeneratorServiceIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/XmEntityGeneratorServiceIntTest.java
@@ -91,7 +91,10 @@ public class XmEntityGeneratorServiceIntTest extends AbstractSpringBootTest {
 
         assertFalse("No tags generated", isEmpty(tags));
 
-        TypeSpec specType = xmEntitySpecService.findTypeByKey("TYPE1.SUBTYPE1");
+        String tk = "TYPE1.SUBTYPE1";
+        TypeSpec specType = xmEntitySpecService
+            .getTypeSpecByKey(tk)
+            .orElseThrow(() -> new IllegalArgumentException("No " + tk + " found"));
         List<TagSpec> tagsSpecs = specType.getTags();
 
         Set<String> specTagsKeys = tagsSpecs.stream().map(TagSpec::getKey).collect(toSet());
@@ -115,7 +118,9 @@ public class XmEntityGeneratorServiceIntTest extends AbstractSpringBootTest {
 
         assertFalse("No locations generated", isEmpty(locations));
 
-        TypeSpec specType = xmEntitySpecService.findTypeByKey("TYPE1.SUBTYPE1");
+        String tk = "TYPE1.SUBTYPE1";
+        TypeSpec specType = xmEntitySpecService.getTypeSpecByKey(tk)
+            .orElseThrow(() -> new IllegalArgumentException("No " + tk + " found"));
         List<LocationSpec> locationSpecs = specType.getLocations();
 
         Set<String> locationSpecKeys = locationSpecs.stream().map(LocationSpec::getKey).collect(toSet());

--- a/src/test/java/com/icthh/xm/ms/entity/service/XmEntityServiceImplUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/XmEntityServiceImplUnitTest.java
@@ -100,7 +100,7 @@ public class XmEntityServiceImplUnitTest extends AbstractUnitTest {
             new UniqueFieldSpec("$.uniqueObjectWithUniqueField.uniqueField"),
             new UniqueFieldSpec("$.notExistsObjectWith.uniqueField")
         )));
-        when(xmEntitySpecService.findTypeByKey(TEST_TYPE_KEY)).thenReturn(typeSpec);
+        when(xmEntitySpecService.getTypeSpecByKey(TEST_TYPE_KEY)).thenReturn(Optional.of(typeSpec));
 
         XmEntity any = any();
         when(xmEntityRepository.save(any)).then(args -> args.getArguments()[0]);
@@ -215,7 +215,7 @@ public class XmEntityServiceImplUnitTest extends AbstractUnitTest {
 
     @Test
     @Transactional
-    public void nameTemplateTest() throws Exception {
+    public void nameTemplateTest() {
         XmEntity entity = new XmEntity();
         entity.setTypeKey("TEST_TYPE_KEY");
         entity.setId(15L);
@@ -225,7 +225,7 @@ public class XmEntityServiceImplUnitTest extends AbstractUnitTest {
 
         String namePattern = "Name generate from ${id} and ${key:unknown} and ${stateKey} and ${data.a.b.c.d.f} and ${data.a.b.c} and ${data.a.b.c.k} and ${data.a.b.c.e[1]} and ${data.a.b.c.e[2]}";
         TypeSpec typeSpec = TypeSpec.builder().namePattern(namePattern).build();
-        when(xmEntitySpecService.findTypeByKey("TEST_TYPE_KEY")).thenReturn(typeSpec);
+        when(xmEntitySpecService.getTypeSpecByKey("TEST_TYPE_KEY")).thenReturn(Optional.of(typeSpec));
 
         xmEntityService.save(entity);
         log.info(entity.getName());

--- a/src/test/java/com/icthh/xm/ms/entity/service/XmEntitySpecServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/XmEntitySpecServiceUnitTest.java
@@ -165,7 +165,7 @@ public class XmEntitySpecServiceUnitTest extends AbstractUnitTest {
     }
 
     @Test
-    public void testFindTypeByKey() {
+    public void testTypeSpecByKey() {
         TypeSpec type = xmEntitySpecService.getTypeSpecByKey(KEY1).orElse(null);
         assertNotNull(type);
         assertEquals(KEY1, type.getKey());
@@ -176,6 +176,20 @@ public class XmEntitySpecServiceUnitTest extends AbstractUnitTest {
 
         Optional<TypeSpec> typeSpecByKey = xmEntitySpecService.getTypeSpecByKey(KEY4);
         assertThat(typeSpecByKey).isEmpty();
+    }
+
+    @Test
+    public void testFindSpecByKey() {
+        TypeSpec type = xmEntitySpecService.findTypeByKey(KEY1);
+        assertNotNull(type);
+        assertEquals(KEY1, type.getKey());
+
+        type = xmEntitySpecService.findTypeByKey(KEY3);
+        assertNotNull(type);
+        assertEquals(KEY3, type.getKey());
+
+        type = xmEntitySpecService.findTypeByKey(KEY4);
+        assertThat(type).isNull();
     }
 
     @Test

--- a/src/test/java/com/icthh/xm/ms/entity/service/XmEntitySpecServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/XmEntitySpecServiceUnitTest.java
@@ -166,16 +166,16 @@ public class XmEntitySpecServiceUnitTest extends AbstractUnitTest {
 
     @Test
     public void testFindTypeByKey() {
-        TypeSpec type = xmEntitySpecService.findTypeByKey(KEY1);
+        TypeSpec type = xmEntitySpecService.getTypeSpecByKey(KEY1).orElse(null);
         assertNotNull(type);
         assertEquals(KEY1, type.getKey());
 
-        type = xmEntitySpecService.findTypeByKey(KEY3);
+        type = xmEntitySpecService.getTypeSpecByKey(KEY3).orElse(null);
         assertNotNull(type);
         assertEquals(KEY3, type.getKey());
 
-        type = xmEntitySpecService.findTypeByKey(KEY4);
-        assertNull(type);
+        Optional<TypeSpec> typeSpecByKey = xmEntitySpecService.getTypeSpecByKey(KEY4);
+        assertThat(typeSpecByKey).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
This pull request switches from `xmEntitySpecService.findTypeByKey` to `xmEntitySpecService.getTypeSpecByKey` with Optional result. 'xmEntitySpecService.findTypeByKey' still used in LEPs, so method should not be removed.