### PR TITLE
add include/exclude filters for elasticsearch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=entity
 profile=dev
-version=2.0.26
+version=2.0.27
 
 # Build properties
 node_version=12.13.0

--- a/src/main/java/com/icthh/xm/ms/entity/repository/search/PermittedSearchRepository.java
+++ b/src/main/java/com/icthh/xm/ms/entity/repository/search/PermittedSearchRepository.java
@@ -5,7 +5,9 @@ import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.springframework.data.elasticsearch.core.query.Query.DEFAULT_PAGE;
 
 import com.icthh.xm.commons.permission.service.PermissionCheckService;
+import com.icthh.xm.ms.entity.domain.XmEntity;
 import com.icthh.xm.ms.entity.repository.search.translator.SpelToElasticTranslator;
+import com.icthh.xm.ms.entity.service.dto.SearchDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -14,6 +16,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
 import org.springframework.data.elasticsearch.core.ScrolledPage;
+import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.SearchQuery;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,7 +44,7 @@ public class PermittedSearchRepository {
      * @return permitted entities
      */
     public <T> List<T> search(String query, Class<T> entityClass, String privilegeKey) {
-        return getElasticsearchTemplate().queryForList(buildQuery(query, null, privilegeKey), entityClass);
+        return getElasticsearchTemplate().queryForList(buildQuery(query, null, privilegeKey, null), entityClass);
     }
 
     /**
@@ -51,9 +54,16 @@ public class PermittedSearchRepository {
      * @param entityClass the search entity class
      * @param privilegeKey the privilege key
      * @return permitted entities
+     * @deprecated use {@link #searchForPage(SearchDto)} instead
      */
+    @Deprecated
     public <T> Page<T> search(String query, Pageable pageable, Class<T> entityClass, String privilegeKey) {
-        return getElasticsearchTemplate().queryForPage(buildQuery(query, pageable, privilegeKey), entityClass);
+        return searchForPage(SearchDto.builder()
+            .entityClass(entityClass)
+            .pageable(pageable)
+            .privilegeKey(privilegeKey)
+            .query(query)
+            .build());
     }
 
     /**
@@ -75,7 +85,7 @@ public class PermittedSearchRepository {
         List<T> resultList = new ArrayList<>();
         try {
             ScrolledPage<T> scrollResult = (ScrolledPage<T>) getElasticsearchTemplate()
-                .startScroll(scrollTimeInMillis, buildQuery(query, pageable, privilegeKey), entityClass);
+                .startScroll(scrollTimeInMillis, buildQuery(query, pageable, privilegeKey, null), entityClass);
 
             scrollId = scrollResult.getScrollId();
 
@@ -94,13 +104,14 @@ public class PermittedSearchRepository {
         return new PageImpl<>(resultList, pageable, resultList.size());
     }
 
-    private SearchQuery buildQuery(String query, Pageable pageable, String privilegeKey) {
+    private SearchQuery buildQuery(String query, Pageable pageable, String privilegeKey, FetchSourceFilter fetchSourceFilter) {
         String permittedQuery = buildPermittedQuery(query, privilegeKey);
 
         log.debug("Executing DSL '{}'", permittedQuery);
 
         return new NativeSearchQueryBuilder()
             .withQuery(queryStringQuery(permittedQuery))
+            .withSourceFilter(fetchSourceFilter)
             .withPageable(pageable == null ? DEFAULT_PAGE : pageable)
             .build();
     }
@@ -129,5 +140,10 @@ public class PermittedSearchRepository {
     // do not renamed! called from lep for not simple string query
     public ElasticsearchTemplate getElasticsearchTemplate() {
         return elasticsearchTemplate;
+    }
+
+    public <T> Page<T> searchForPage(SearchDto searchDto) {
+        SearchQuery query = buildQuery(searchDto.getQuery(), searchDto.getPageable(), searchDto.getPrivilegeKey(), searchDto.getFetchSourceFilter());
+        return getElasticsearchTemplate().queryForPage(query, searchDto.getEntityClass());
     }
 }

--- a/src/main/java/com/icthh/xm/ms/entity/service/XmEntityService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/XmEntityService.java
@@ -10,6 +10,7 @@ import com.icthh.xm.ms.entity.projection.XmEntityIdKeyTypeKey;
 import com.icthh.xm.ms.entity.projection.XmEntityStateProjection;
 import com.icthh.xm.ms.entity.service.dto.LinkSourceDto;
 
+import com.icthh.xm.ms.entity.service.dto.SearchDto;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpEntity;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +60,8 @@ public interface XmEntityService extends ResourceRepository {
     void delete(Long id);
 
     Page<XmEntity> search(String query, Pageable pageable, String privilegeKey);
+
+    Page<XmEntity> searchV2(SearchDto searchDto);
 
     Page<XmEntity> search(String template,
                           TemplateParamsHolder templateParamsHolder,

--- a/src/main/java/com/icthh/xm/ms/entity/service/dto/SearchDto.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/dto/SearchDto.java
@@ -1,0 +1,17 @@
+package com.icthh.xm.ms.entity.service.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
+
+@Builder
+@Getter
+public class SearchDto {
+
+    private String query;
+    private Pageable pageable;
+    private String privilegeKey;
+    private FetchSourceFilter fetchSourceFilter;
+    private Class entityClass;
+}

--- a/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
@@ -74,6 +74,7 @@ import com.icthh.xm.ms.entity.service.XmEntityService;
 import com.icthh.xm.ms.entity.service.XmEntitySpecService;
 import com.icthh.xm.ms.entity.service.XmEntityTemplatesSpecService;
 import com.icthh.xm.ms.entity.service.dto.LinkSourceDto;
+import com.icthh.xm.ms.entity.service.dto.SearchDto;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import java.net.URI;
@@ -490,6 +491,15 @@ public class XmEntityServiceImpl implements XmEntityService {
     @PrivilegeDescription("Privilege to search for the xmEntity corresponding to the query")
     public Page<XmEntity> search(String query, Pageable pageable, String privilegeKey) {
         return xmEntityPermittedSearchRepository.search(query, pageable, XmEntity.class, privilegeKey);
+    }
+
+    @LogicExtensionPoint("SearchV2")
+    @Override
+    @Transactional(readOnly = true)
+    @FindWithPermission("XMENTITY.SEARCH")
+    @PrivilegeDescription("Privilege to search for the xmEntity corresponding to the query")
+    public Page<XmEntity> searchV2(SearchDto searchDto) {
+        return xmEntityPermittedSearchRepository.searchForPage(searchDto);
     }
 
     @LogicExtensionPoint(value = "SearchByTemplate", resolver = TemplateTypeKeyResolver.class)

--- a/src/test/java/com/icthh/xm/ms/entity/web/rest/XmEntityResourceIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/web/rest/XmEntityResourceIntTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -778,6 +779,63 @@ public class XmEntityResourceIntTest extends AbstractSpringBootTest {
             .andExpect(jsonPath("$.[*].data").value(hasItem(DEFAULT_DATA)))
             .andExpect(jsonPath("$.[*].removed").value(hasItem(DEFAULT_REMOVED.booleanValue())));
     }
+
+    @Test
+    @Transactional
+    public void searchXmEntityWithExcludeFields() throws Exception {
+        xmEntity = transactionService.inNestedTransaction(() -> {
+            // Initialize the database
+            return xmEntityServiceImpl.save(xmEntity);
+        }, this::setup);
+        xmEntitySearchRepository.refresh();
+
+        // Search the xmEntity
+        restXmEntityMockMvc.perform(get("/api/_search/v2/xm-entities?query=id:" + xmEntity.getId()
+            +"&excludes=id&excludes=key&excludes=typeKey"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].key").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].typeKey").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].stateKey").value(hasItem(DEFAULT_STATE_KEY)))
+            .andExpect(jsonPath("$.[*].name").value(hasItem(DEFAULT_NAME)))
+            .andExpect(jsonPath("$.[*].startDate").value(hasItem(MOCKED_START_DATE.toString())))
+            .andExpect(jsonPath("$.[*].updateDate").value(hasItem(MOCKED_UPDATE_DATE.toString())))
+            .andExpect(jsonPath("$.[*].endDate").value(hasItem(DEFAULT_END_DATE.toString())))
+            .andExpect(jsonPath("$.[*].avatarUrl").value(hasItem(containsString("aaaaa.jpg"))))
+            .andExpect(jsonPath("$.[*].description").value(hasItem(DEFAULT_DESCRIPTION.toString())))
+            .andExpect(jsonPath("$.[*].data").value(hasItem(DEFAULT_DATA)))
+            .andExpect(jsonPath("$.[*].removed").value(hasItem(DEFAULT_REMOVED.booleanValue())));
+    }
+
+    @Test
+    @Transactional
+    public void searchXmEntityWithIncludeFields() throws Exception {
+        xmEntity = transactionService.inNestedTransaction(() -> {
+            // Initialize the database
+            return xmEntityServiceImpl.save(xmEntity);
+        }, this::setup);
+        xmEntitySearchRepository.refresh();
+
+        // Search the xmEntity
+        restXmEntityMockMvc.perform(get("/api/_search/v2/xm-entities?query=id:" + xmEntity.getId()
+            +"&includes=id&includes=key&includes=typeKey"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(xmEntity.getId().intValue())))
+            .andExpect(jsonPath("$.[*].key").value(hasItem(DEFAULT_KEY)))
+            .andExpect(jsonPath("$.[*].typeKey").value(hasItem(DEFAULT_TYPE_KEY)))
+            .andExpect(jsonPath("$.[*].stateKey").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].name").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].startDate").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].updateDate").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].endDate").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].avatarUrl").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].description").value(hasItem(nullValue())))
+            .andExpect(jsonPath("$.[*].removed").value(hasItem(nullValue())));
+    }
+
+
 
     @Test
     @Transactional


### PR DESCRIPTION
 - why is this for?
In order to have possibility to include/exclude data from  elastic search results and write such  queries:
`http://localhost:8080/entity/api/_search/v2/xm-entities?query=typeKey:SOME-TYPE-KEY&excludes=data.title.name&excludes=id`
 - why i had to implement new endpoint?
 Because i cannot just add new parameter(FetchSourceFilter) to XmEntityServiceImpl#search(String, Pageable, String)  method. I would break lep functionality in this case.
 - why i implemented SearchDto?
 In order to have possibility add  new endpoint parameters for search endpoint and avoid current situation in future 
