### PR TITLE
fix bug with privilege key argument instead of searchDto

### DIFF
--- a/src/main/java/com/icthh/xm/ms/entity/repository/search/PermittedSearchRepository.java
+++ b/src/main/java/com/icthh/xm/ms/entity/repository/search/PermittedSearchRepository.java
@@ -52,18 +52,16 @@ public class PermittedSearchRepository {
      * @param query the elastic query
      * @param pageable the page info
      * @param entityClass the search entity class
-     * @param privilegeKey the privilege key
      * @return permitted entities
-     * @deprecated use {@link #searchForPage(SearchDto)} instead
+     * @deprecated use {@link #searchForPage(SearchDto, String)} instead
      */
     @Deprecated
     public <T> Page<T> search(String query, Pageable pageable, Class<T> entityClass, String privilegeKey) {
         return searchForPage(SearchDto.builder()
             .entityClass(entityClass)
             .pageable(pageable)
-            .privilegeKey(privilegeKey)
             .query(query)
-            .build());
+            .build(), privilegeKey);
     }
 
     /**
@@ -142,8 +140,8 @@ public class PermittedSearchRepository {
         return elasticsearchTemplate;
     }
 
-    public <T> Page<T> searchForPage(SearchDto searchDto) {
-        SearchQuery query = buildQuery(searchDto.getQuery(), searchDto.getPageable(), searchDto.getPrivilegeKey(), searchDto.getFetchSourceFilter());
+    public <T> Page<T> searchForPage(SearchDto searchDto, String privilegeKey) {
+        SearchQuery query = buildQuery(searchDto.getQuery(), searchDto.getPageable(), privilegeKey, searchDto.getFetchSourceFilter());
         return getElasticsearchTemplate().queryForPage(query, searchDto.getEntityClass());
     }
 }

--- a/src/main/java/com/icthh/xm/ms/entity/service/XmEntityService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/XmEntityService.java
@@ -61,7 +61,7 @@ public interface XmEntityService extends ResourceRepository {
 
     Page<XmEntity> search(String query, Pageable pageable, String privilegeKey);
 
-    Page<XmEntity> searchV2(SearchDto searchDto);
+    Page<XmEntity> searchV2(SearchDto searchDto, String privilegeKey);
 
     Page<XmEntity> search(String template,
                           TemplateParamsHolder templateParamsHolder,

--- a/src/main/java/com/icthh/xm/ms/entity/service/dto/SearchDto.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/dto/SearchDto.java
@@ -11,7 +11,6 @@ public class SearchDto {
 
     private String query;
     private Pageable pageable;
-    private String privilegeKey;
     private FetchSourceFilter fetchSourceFilter;
     private Class entityClass;
 }

--- a/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
@@ -498,8 +498,8 @@ public class XmEntityServiceImpl implements XmEntityService {
     @Transactional(readOnly = true)
     @FindWithPermission("XMENTITY.SEARCH")
     @PrivilegeDescription("Privilege to search for the xmEntity corresponding to the query")
-    public Page<XmEntity> searchV2(SearchDto searchDto) {
-        return xmEntityPermittedSearchRepository.searchForPage(searchDto);
+    public Page<XmEntity> searchV2(SearchDto searchDto, String privilegeKey) {
+        return xmEntityPermittedSearchRepository.searchForPage(searchDto, privilegeKey);
     }
 
     @LogicExtensionPoint(value = "SearchByTemplate", resolver = TemplateTypeKeyResolver.class)

--- a/src/main/java/com/icthh/xm/ms/entity/web/rest/XmEntityResource.java
+++ b/src/main/java/com/icthh/xm/ms/entity/web/rest/XmEntityResource.java
@@ -253,7 +253,7 @@ public class XmEntityResource {
             .entityClass(XmEntity.class)
             .fetchSourceFilter(fetchSourceFilter)
             .build();
-        Page<XmEntity> page = xmEntityService.searchV2(searchDto);
+        Page<XmEntity> page = xmEntityService.searchV2(searchDto, null);
         HttpHeaders headers = PaginationUtil
             .generateSearchPaginationHttpHeaders(query, page,
                 "/api/_search/xm-entities");


### PR DESCRIPTION
when i  deployed code from [this](https://github.com/xm-online/xm-ms-entity/pull/239) PR to test env i have found that request is failed because first parameter that passed to method  is privilege key string instead of my SearchDto. The reason is 