### PR TITLE
Override default permission filtering logic with custom PermissionMsN…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ spotbugs_plugin_version=3.0.0
 
 ## XM custom properties
 lombok_version=1.18.10
-xm_commons_version=2.1.25
+xm_commons_version=2.1.31
 
 squiggly_filter_version=1.3.17
 

--- a/src/main/java/com/icthh/xm/ms/entity/security/filter/EntityFunctionPermissionMsNameFilter.java
+++ b/src/main/java/com/icthh/xm/ms/entity/security/filter/EntityFunctionPermissionMsNameFilter.java
@@ -1,0 +1,25 @@
+package com.icthh.xm.ms.entity.security.filter;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.startsWithIgnoreCase;
+
+import com.icthh.xm.commons.permission.service.filter.PermissionMsNameFilter;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component("permissionMsNameFilter")
+public class EntityFunctionPermissionMsNameFilter implements PermissionMsNameFilter {
+
+    private static final String CUSTOM_PRIVILEGES_SECTION_PREFIX = "entity-";
+
+    @Value("${spring.application.name}")
+    private String msName;
+
+    @Override
+    public boolean filterPermission(String permissionMsName) {
+        return isBlank(msName) || StringUtils.equals(msName, permissionMsName)
+            || (isNotBlank(permissionMsName) && startsWithIgnoreCase(permissionMsName, CUSTOM_PRIVILEGES_SECTION_PREFIX));
+    }
+}

--- a/src/test/java/com/icthh/xm/ms/entity/security/filter/EntityFunctionPermissionMsNameFilterUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/security/filter/EntityFunctionPermissionMsNameFilterUnitTest.java
@@ -1,0 +1,40 @@
+package com.icthh.xm.ms.entity.security.filter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.icthh.xm.ms.entity.AbstractUnitTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EntityFunctionPermissionMsNameFilterUnitTest extends AbstractUnitTest {
+
+    private final EntityFunctionPermissionMsNameFilter filter = new EntityFunctionPermissionMsNameFilter();
+    private final static String APP_NAME = "appName";
+
+    @Test
+    public void testFilterPermission() {
+        assertTrue(filter.filterPermission(null));
+        assertTrue(filter.filterPermission(""));
+        assertTrue(filter.filterPermission("other app name"));
+        assertTrue(filter.filterPermission(APP_NAME));
+
+        ReflectionTestUtils.setField(filter, "msName", APP_NAME, String.class);
+
+        assertFalse(filter.filterPermission(null));
+        assertFalse(filter.filterPermission(""));
+        assertFalse(filter.filterPermission("other app name"));
+        assertTrue(filter.filterPermission(APP_NAME));
+
+        ReflectionTestUtils.setField(filter, "msName", "entity", String.class);
+        assertTrue(filter.filterPermission("entity"));
+        assertTrue(filter.filterPermission("entity-functions"));
+        assertTrue(filter.filterPermission("entity-dynamic-permission"));
+
+        ReflectionTestUtils.setField(filter, "msName", "communication", String.class);
+        assertFalse(filter.filterPermission("entity"));
+    }
+}


### PR DESCRIPTION
…ameFilter bean, that will return true in a scenario when ms name from permission is a case-ignored prefix of constant 'entity-functions'