### PR TITLE
Add new method `isValidJsonSchema` to XmEntityService

### DIFF
--- a/src/main/java/com/icthh/xm/ms/entity/service/XmEntityService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/XmEntityService.java
@@ -140,4 +140,12 @@ public interface XmEntityService extends ResourceRepository {
 
     byte[] exportEntities(String fileFormat, String typeKey);
 
+    /**
+     * Checks an entity against a json schema.
+     * If the scheme is absent - returns true.
+     *
+     * @param value Entity of XM
+     * @return True if entity is valid
+     */
+    boolean isValidJsonSchema(XmEntity value);
 }

--- a/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/impl/XmEntityServiceImpl.java
@@ -64,6 +64,7 @@ import com.icthh.xm.ms.entity.repository.XmEntityPermittedRepository;
 import com.icthh.xm.ms.entity.repository.XmEntityRepositoryInternal;
 import com.icthh.xm.ms.entity.repository.search.XmEntityPermittedSearchRepository;
 import com.icthh.xm.ms.entity.service.AttachmentService;
+import com.icthh.xm.ms.entity.service.JsonValidationService;
 import com.icthh.xm.ms.entity.service.LifecycleLepStrategy;
 import com.icthh.xm.ms.entity.service.LifecycleLepStrategyFactory;
 import com.icthh.xm.ms.entity.service.LinkService;
@@ -135,6 +136,7 @@ public class XmEntityServiceImpl implements XmEntityService {
     private final TypeKeyWithExtends typeKeyWithExtends;
     private final SimpleTemplateProcessor simpleTemplateProcessors;
     private final EventRepository eventRepository;
+    private final JsonValidationService validator;
 
     private XmEntityServiceImpl self;
 
@@ -866,4 +868,10 @@ public class XmEntityServiceImpl implements XmEntityService {
             .orElse(null);
     }
 
+    @Override
+    public boolean isValidJsonSchema(XmEntity value) {
+        return xmEntitySpecService.getDataJsonSchemaByKey(value.getTypeKey())
+            .map(js -> validator.validateJson(value.getData(), js).isSuccess())
+            .orElse(true);
+    }
 }

--- a/src/test/java/com/icthh/xm/ms/entity/service/impl/EntityServiceImplIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/impl/EntityServiceImplIntTest.java
@@ -39,6 +39,7 @@ import com.icthh.xm.ms.entity.repository.XmEntityRepositoryInternal;
 import com.icthh.xm.ms.entity.repository.search.XmEntityPermittedSearchRepository;
 import com.icthh.xm.ms.entity.repository.search.XmEntitySearchRepository;
 import com.icthh.xm.ms.entity.service.AttachmentService;
+import com.icthh.xm.ms.entity.service.JsonValidationService;
 import com.icthh.xm.ms.entity.service.LifecycleLepStrategyFactory;
 import com.icthh.xm.ms.entity.service.LinkService;
 import com.icthh.xm.ms.entity.service.ProfileService;
@@ -186,7 +187,8 @@ public class EntityServiceImplIntTest extends AbstractSpringBootTest {
             springXmEntityRepository,
             new TypeKeyWithExtends(tenantConfigService),
             new SimpleTemplateProcessor(objectMapper),
-            eventRepository
+            eventRepository,
+            mock(JsonValidationService.class)
         );
         xmEntityService.setSelf(xmEntityService);
 

--- a/src/test/java/com/icthh/xm/ms/entity/web/rest/XmEntityResourceExtendedIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/web/rest/XmEntityResourceExtendedIntTest.java
@@ -77,6 +77,7 @@ import com.icthh.xm.ms.entity.service.AttachmentService;
 import com.icthh.xm.ms.entity.service.CalendarService;
 import com.icthh.xm.ms.entity.service.EventService;
 import com.icthh.xm.ms.entity.service.FunctionService;
+import com.icthh.xm.ms.entity.service.JsonValidationService;
 import com.icthh.xm.ms.entity.service.LifecycleLepStrategyFactory;
 import com.icthh.xm.ms.entity.service.LinkService;
 import com.icthh.xm.ms.entity.service.ProfileService;
@@ -360,7 +361,8 @@ public class XmEntityResourceExtendedIntTest extends AbstractSpringBootTest {
                                                                       springXmEntityRepository,
                                                                       new TypeKeyWithExtends(tenantConfigService),
                                                                       new SimpleTemplateProcessor(objectMapper),
-                                                                      eventRepository);
+                                                                      eventRepository,
+                                                                      mock(JsonValidationService.class));
 
         xmEntityService.setSelf(xmEntityService);
         this.xmEntityService = xmEntityService;

--- a/src/test/java/com/icthh/xm/ms/entity/web/rest/XmEntityResourceIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/web/rest/XmEntityResourceIntTest.java
@@ -53,6 +53,7 @@ import com.icthh.xm.ms.entity.repository.search.XmEntityPermittedSearchRepositor
 import com.icthh.xm.ms.entity.repository.search.XmEntitySearchRepository;
 import com.icthh.xm.ms.entity.service.AttachmentService;
 import com.icthh.xm.ms.entity.service.FunctionService;
+import com.icthh.xm.ms.entity.service.JsonValidationService;
 import com.icthh.xm.ms.entity.service.LifecycleLepStrategyFactory;
 import com.icthh.xm.ms.entity.service.LinkService;
 import com.icthh.xm.ms.entity.service.ProfileService;
@@ -285,7 +286,9 @@ public class XmEntityResourceIntTest extends AbstractSpringBootTest {
                                                       springXmEntityRepository,
                                                       new TypeKeyWithExtends(tenantConfigService),
                                                       new SimpleTemplateProcessor(objectMapper),
-                                                      eventRepository);
+                                                      eventRepository,
+                                                      mock(JsonValidationService.class));
+
         xmEntityServiceImpl.setSelf(xmEntityServiceImpl);
 
         this.xmEntityServiceImpl = xmEntityServiceImpl;


### PR DESCRIPTION
This change is necessary so that external microservices can manually validate an entity, in  case that validation on this microservice (xm-entity) is disabled.
And such need has appeared on the project