### PR TITLE
Feature/tx function

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=entity
 profile=dev
-version=2.2.55
+version=2.2.56
 
 # Build properties
 node_version=12.13.0

--- a/src/main/java/com/icthh/xm/ms/entity/config/MicroserviceSecurityConfiguration.java
+++ b/src/main/java/com/icthh/xm/ms/entity/config/MicroserviceSecurityConfiguration.java
@@ -1,14 +1,24 @@
 package com.icthh.xm.ms.entity.config;
 
 import com.icthh.xm.commons.permission.constants.RoleConstant;
-import com.icthh.xm.commons.security.oauth2.ConfigSignatureVerifierClient;
-import com.icthh.xm.commons.security.oauth2.OAuth2JwtAccessTokenConverter;
-import com.icthh.xm.commons.security.oauth2.OAuth2Properties;
-import com.icthh.xm.commons.security.oauth2.OAuth2SignatureVerifierClient;
+import com.icthh.xm.ms.entity.security.DomainJwtAccessTokenConverter;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cloud.client.loadbalancer.RestTemplateCustomizer;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -19,16 +29,13 @@ import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenCo
 import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
 import org.springframework.web.client.RestTemplate;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableResourceServer
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerAdapter {
 
-    private final OAuth2Properties oauth2Properties;
-
-    public MicroserviceSecurityConfiguration(OAuth2Properties oauth2Properties) {
-        this.oauth2Properties = oauth2Properties;
-    }
+    private final DiscoveryClient discoveryClient;
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
@@ -60,28 +67,32 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
     }
 
     @Bean
-    public JwtAccessTokenConverter jwtAccessTokenConverter(OAuth2SignatureVerifierClient signatureVerifierClient) {
-        return new OAuth2JwtAccessTokenConverter(oauth2Properties, signatureVerifierClient);
+    public JwtAccessTokenConverter jwtAccessTokenConverter(
+            @Qualifier("loadBalancedRestTemplate") RestTemplate keyUriRestTemplate)
+        throws CertificateException, IOException {
+
+        DomainJwtAccessTokenConverter converter = new DomainJwtAccessTokenConverter();
+        converter.setVerifierKey(getKeyFromConfigServer(keyUriRestTemplate));
+        return converter;
     }
 
-    @Bean
-    @Qualifier("loadBalancedRestTemplate")
-    public RestTemplate loadBalancedRestTemplate(RestTemplateCustomizer customizer) {
-        RestTemplate restTemplate = new RestTemplate();
-        customizer.customize(restTemplate);
-        return restTemplate;
-    }
+    private String getKeyFromConfigServer(RestTemplate keyUriRestTemplate) throws CertificateException, IOException {
+        // Load available UAA servers
+        discoveryClient.getServices();
+        HttpEntity<Void> request = new HttpEntity<Void>(new HttpHeaders());
+        String content = keyUriRestTemplate
+            .exchange("http://config/api/token_key", HttpMethod.GET, request, String.class).getBody();
 
-    @Bean
-    @Qualifier("vanillaRestTemplate")
-    public RestTemplate vanillaRestTemplate() {
-        return new RestTemplate();
-    }
+        if (StringUtils.isBlank(content)) {
+            throw new CertificateException("Received empty certificate from config.");
+        }
 
-    @Bean
-    public ConfigSignatureVerifierClient configSignatureVerifierClient(
-        @Qualifier("loadBalancedRestTemplate") RestTemplate restTemplate) {
-        return new ConfigSignatureVerifierClient(oauth2Properties, restTemplate);
-    }
+        try (InputStream fin = new ByteArrayInputStream(content.getBytes())) {
 
+            CertificateFactory f = CertificateFactory.getInstance(Constants.CERTIFICATE);
+            X509Certificate certificate = (X509Certificate) f.generateCertificate(fin);
+            PublicKey pk = certificate.getPublicKey();
+            return String.format(Constants.PUBLIC_KEY, new String(Base64.getEncoder().encode(pk.getEncoded())));
+        }
+    }
 }

--- a/src/main/java/com/icthh/xm/ms/entity/domain/spec/FunctionSpec.java
+++ b/src/main/java/com/icthh/xm/ms/entity/domain/spec/FunctionSpec.java
@@ -17,7 +17,7 @@ import static com.icthh.xm.ms.entity.service.impl.FunctionServiceImpl.XM_ENITITY
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"key", "name", "actionName", "allowedStateKeys", "withEntityId", "isShowFormWithoutData", "inputSpec", "inputForm",
-    "contextDataSpec", "contextDataForm", "showResponse", "onlyData", "validateFunctionInput"})
+    "contextDataSpec", "contextDataForm", "showResponse", "onlyData", "validateFunctionInput", "txType"})
 @Data
 public class FunctionSpec {
 

--- a/src/main/java/com/icthh/xm/ms/entity/domain/spec/FunctionSpec.java
+++ b/src/main/java/com/icthh/xm/ms/entity/domain/spec/FunctionSpec.java
@@ -21,6 +21,10 @@ import static com.icthh.xm.ms.entity.service.impl.FunctionServiceImpl.XM_ENITITY
 @Data
 public class FunctionSpec {
 
+    public enum FunctionTxTypes {
+        NO_TX, READ_ONLY, TX
+    }
+
     /**
      * Unique in tenant function key.
      */
@@ -103,6 +107,9 @@ public class FunctionSpec {
 
     @JsonProperty("anonymous")
     private Boolean anonymous;
+
+    @JsonProperty("txType")
+    private FunctionTxTypes txType = FunctionTxTypes.TX;
 
     public Boolean getSaveFunctionContext() {
         return saveFunctionContext == null ? false : saveFunctionContext;

--- a/src/main/java/com/icthh/xm/ms/entity/service/impl/FunctionTxControl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/impl/FunctionTxControl.java
@@ -1,0 +1,15 @@
+package com.icthh.xm.ms.entity.service.impl;
+
+import com.icthh.xm.ms.entity.domain.FunctionContext;
+
+import java.util.function.Supplier;
+
+public interface FunctionTxControl {
+
+    FunctionContext executeInTransaction(Supplier<FunctionContext> executor);
+
+    FunctionContext executeInTransactionWithRoMode(Supplier<FunctionContext> executor);
+
+    FunctionContext executeWithNoTx(Supplier<FunctionContext> executor);
+
+}

--- a/src/main/java/com/icthh/xm/ms/entity/service/impl/FunctionTxControlImpl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/impl/FunctionTxControlImpl.java
@@ -1,0 +1,28 @@
+package com.icthh.xm.ms.entity.service.impl;
+
+import com.icthh.xm.ms.entity.domain.FunctionContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Supplier;
+
+@Service
+public class FunctionTxControlImpl implements FunctionTxControl {
+    @Override
+    @Transactional
+    public FunctionContext executeInTransaction(Supplier<FunctionContext> executor) {
+        return executor.get();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FunctionContext executeInTransactionWithRoMode(Supplier<FunctionContext> executor) {
+        return executor.get();
+    }
+
+    @Override
+    public FunctionContext executeWithNoTx(Supplier<FunctionContext> executor) {
+        return executor.get();
+    }
+
+}

--- a/src/test/java/com/icthh/xm/ms/entity/service/impl/FunctionServiceImplTxControlUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/impl/FunctionServiceImplTxControlUnitTest.java
@@ -1,0 +1,195 @@
+package com.icthh.xm.ms.entity.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import com.icthh.xm.ms.entity.AbstractUnitTest;
+import com.icthh.xm.ms.entity.config.XmEntityTenantConfigService;
+import com.icthh.xm.ms.entity.config.XmEntityTenantConfigService.XmEntityTenantConfig;
+import com.icthh.xm.ms.entity.domain.FunctionContext;
+import com.icthh.xm.ms.entity.domain.ext.IdOrKey;
+import com.icthh.xm.ms.entity.domain.spec.FunctionSpec;
+import com.icthh.xm.ms.entity.security.access.DynamicPermissionCheckService;
+import com.icthh.xm.ms.entity.service.FunctionContextService;
+import com.icthh.xm.ms.entity.service.FunctionExecutorService;
+import com.icthh.xm.ms.entity.service.XmEntityService;
+import com.icthh.xm.ms.entity.service.XmEntitySpecService;
+import com.icthh.xm.ms.entity.service.json.JsonValidationService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.icthh.xm.ms.entity.domain.ext.IdOrKey.SELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FunctionServiceImplTxControlUnitTest extends AbstractUnitTest {
+
+    private FunctionServiceImpl functionService;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    private XmEntitySpecService xmEntitySpecService;
+    private XmEntityService xmEntityService;
+    private FunctionExecutorService functionExecutorService;
+    private FunctionContextService functionContextService;
+    private DynamicPermissionCheckService dynamicPermissionCheckService;
+    private JsonValidationService jsonValidationService;
+    private XmEntityTenantConfigService xmEntityTenantConfigService;
+    private XmEntityTenantConfig xmEntityTenantConfig;
+
+    private FunctionTxControl functionTxControl;
+
+    private String functionName = "F_NAME";
+
+    private IdOrKey key = SELF;
+
+    @Before
+    public void setUp() {
+        xmEntitySpecService = Mockito.mock(XmEntitySpecService.class);
+        xmEntityService = Mockito.mock(XmEntityService.class);
+        functionExecutorService = Mockito.mock(FunctionExecutorService.class);
+        functionContextService = Mockito.mock(FunctionContextService.class);
+        dynamicPermissionCheckService = Mockito.mock(DynamicPermissionCheckService.class);
+        xmEntityTenantConfigService = Mockito.mock(XmEntityTenantConfigService.class);
+        functionTxControl = spy(new FunctionTxControlImpl());
+        jsonValidationService = spy(new JsonValidationService(new ObjectMapper()));
+        functionService = new FunctionServiceImpl(xmEntitySpecService, xmEntityService,
+            functionExecutorService, functionContextService, dynamicPermissionCheckService,
+                jsonValidationService, xmEntityTenantConfigService, functionTxControl);
+        xmEntityTenantConfig = new XmEntityTenantConfig();
+        when(xmEntityTenantConfigService.getXmEntityTenantConfig()).thenReturn(xmEntityTenantConfig);
+    }
+
+    @Test
+    public void executeWithNoTxMode() {
+
+        FunctionSpec spec = getFunctionSpec(s -> {
+            s.setSaveFunctionContext(Boolean.FALSE);
+            s.setTxType(FunctionSpec.FunctionTxTypes.NO_TX);
+            return s;
+        });
+
+        Map<String, Object> context = Maps.newHashMap();
+        context.put("key1", "val1");
+
+        Map<String, Object> data = Maps.newHashMap();
+        data.put("KEY1", "VAL1");
+
+        when(xmEntitySpecService.findFunction(functionName))
+            .thenReturn(Optional.of(spec));
+
+        when(functionExecutorService.execute(functionName, context, null))
+            .thenReturn(data);
+
+        when(functionContextService.save(any())).thenReturn(new FunctionContext());
+
+        verify(functionTxControl, never()).executeWithNoTx(any());
+        verify(functionTxControl, never()).executeInTransactionWithRoMode(any());
+        verify(functionTxControl, never()).executeInTransaction(any());
+
+        FunctionContext fc = functionService.execute(functionName, context, null);
+        assertThat(fc.getTypeKey()).isEqualTo(functionName);
+        assertThat(fc.getKey()).contains(functionName);
+        assertThat(fc.getData().keySet()).containsSequence(data.keySet().toArray(new String[0]));
+
+        verify(functionContextService, never()).save(any());
+        verify(functionTxControl, times(1)).executeWithNoTx(any());
+        verify(functionTxControl, never()).executeInTransactionWithRoMode(any());
+        verify(functionTxControl, never()).executeInTransaction(any());
+    }
+
+    @Test
+    public void executeWitReadOnlyTxModeAndSaveCtxFalse() {
+
+        FunctionSpec spec = getFunctionSpec(s -> {
+            s.setSaveFunctionContext(Boolean.FALSE);
+            s.setTxType(FunctionSpec.FunctionTxTypes.READ_ONLY);
+            return s;
+        });
+
+        Map<String, Object> context = Maps.newHashMap();
+        context.put("key1", "val1");
+
+        Map<String, Object> data = Maps.newHashMap();
+        data.put("KEY1", "VAL1");
+
+        when(xmEntitySpecService.findFunction(functionName))
+            .thenReturn(Optional.of(spec));
+
+        when(functionExecutorService.execute(functionName, context, null))
+            .thenReturn(data);
+
+        when(functionContextService.save(any())).thenReturn(new FunctionContext());
+
+        verify(functionTxControl, never()).executeWithNoTx(any());
+        verify(functionTxControl, never()).executeInTransactionWithRoMode(any());
+        verify(functionTxControl, never()).executeInTransaction(any());
+
+        FunctionContext fc = functionService.execute(functionName, context, null);
+        assertThat(fc.getTypeKey()).isEqualTo(functionName);
+        assertThat(fc.getKey()).contains(functionName);
+        assertThat(fc.getData().keySet()).containsSequence(data.keySet().toArray(new String[0]));
+
+        verify(functionContextService, never()).save(any());
+        verify(functionTxControl, never()).executeWithNoTx(any());
+        verify(functionTxControl, times(1)).executeInTransactionWithRoMode(any());
+        verify(functionTxControl, never()).executeInTransaction(any());
+    }
+
+    @Test
+    public void executeWitRWTxModeAndSaveCtxFalse() {
+
+        FunctionSpec spec = getFunctionSpec(s -> {
+            s.setSaveFunctionContext(Boolean.FALSE);
+            s.setTxType(FunctionSpec.FunctionTxTypes.TX);
+            return s;
+        });
+
+        Map<String, Object> context = Maps.newHashMap();
+        context.put("key1", "val1");
+
+        Map<String, Object> data = Maps.newHashMap();
+        data.put("KEY1", "VAL1");
+
+        when(xmEntitySpecService.findFunction(functionName))
+            .thenReturn(Optional.of(spec));
+
+        when(functionExecutorService.execute(functionName, context, null))
+            .thenReturn(data);
+
+        when(functionContextService.save(any())).thenReturn(new FunctionContext());
+
+        verify(functionTxControl, never()).executeWithNoTx(any());
+        verify(functionTxControl, never()).executeInTransactionWithRoMode(any());
+        verify(functionTxControl, never()).executeInTransaction(any());
+
+        FunctionContext fc = functionService.execute(functionName, context, null);
+        assertThat(fc.getTypeKey()).isEqualTo(functionName);
+        assertThat(fc.getKey()).contains(functionName);
+        assertThat(fc.getData().keySet()).containsSequence(data.keySet().toArray(new String[0]));
+
+        verify(functionContextService, never()).save(any());
+        verify(functionTxControl, never()).executeWithNoTx(any());
+        verify(functionTxControl, never()).executeInTransactionWithRoMode(any());
+        verify(functionTxControl, times(1)).executeInTransaction(any());
+    }
+
+    private FunctionSpec getFunctionSpec(Function<FunctionSpec, FunctionSpec> functionSpec) {
+        FunctionSpec spec = new FunctionSpec();
+        spec.setKey(functionName);
+        return functionSpec.apply(spec);
+    }
+
+}

--- a/src/test/java/com/icthh/xm/ms/entity/service/impl/FunctionServiceImplUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/impl/FunctionServiceImplUnitTest.java
@@ -12,12 +12,16 @@ import com.icthh.xm.ms.entity.projection.XmEntityStateProjection;
 import com.icthh.xm.ms.entity.security.access.DynamicPermissionCheckService;
 import com.icthh.xm.ms.entity.service.FunctionContextService;
 import com.icthh.xm.ms.entity.service.FunctionExecutorService;
-import com.icthh.xm.ms.entity.service.json.JsonValidationService;
 import com.icthh.xm.ms.entity.service.XmEntityService;
 import com.icthh.xm.ms.entity.service.XmEntitySpecService;
+import com.icthh.xm.ms.entity.service.json.JsonValidationService;
 import org.assertj.core.util.Lists;
 import org.jetbrains.annotations.NotNull;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
@@ -30,7 +34,13 @@ import java.util.Optional;
 import static com.icthh.xm.ms.entity.domain.ext.IdOrKey.SELF;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class FunctionServiceImplUnitTest extends AbstractUnitTest {
 
@@ -51,6 +61,8 @@ public class FunctionServiceImplUnitTest extends AbstractUnitTest {
     private XmEntityTenantConfigService xmEntityTenantConfigService;
     private XmEntityTenantConfig xmEntityTenantConfig;
 
+    private FunctionTxControl functionTxControl;
+
     private String functionName = "F_NAME";
 
     private IdOrKey key = SELF;
@@ -66,10 +78,11 @@ public class FunctionServiceImplUnitTest extends AbstractUnitTest {
         functionContextService = Mockito.mock(FunctionContextService.class);
         dynamicPermissionCheckService = Mockito.mock(DynamicPermissionCheckService.class);
         xmEntityTenantConfigService = Mockito.mock(XmEntityTenantConfigService.class);
+        functionTxControl = new FunctionTxControlImpl();
         jsonValidationService = spy(new JsonValidationService(new ObjectMapper()));
         functionService = new FunctionServiceImpl(xmEntitySpecService, xmEntityService,
             functionExecutorService, functionContextService, dynamicPermissionCheckService,
-                jsonValidationService, xmEntityTenantConfigService);
+                jsonValidationService, xmEntityTenantConfigService, functionTxControl);
         xmEntityTenantConfig = new XmEntityTenantConfig();
         when(xmEntityTenantConfigService.getXmEntityTenantConfig()).thenReturn(xmEntityTenantConfig);
     }


### PR DESCRIPTION
Feature allows to specify HOW lep function call will be executed

Using FunctionSpec.txType developer/configurator is able to select one of implementations

```
protected FunctionContext callLepExecutor(FunctionSpec.FunctionTxTypes txType, Supplier<FunctionContext> logic) {
        switch (txType) {
            case READ_ONLY: return functionTxControl.executeInTransactionWithRoMode(logic);
            case NO_TX: return functionTxControl.executeWithNoTx(logic);
            default: return functionTxControl.executeInTransaction(logic);
        }
    }
```

```
    @Override
    @Transactional
    public FunctionContext executeInTransaction(Supplier<FunctionContext> executor) {
        return executor.get();
    }

    @Override
    @Transactional(readOnly = true)
    public FunctionContext executeInTransactionWithRoMode(Supplier<FunctionContext> executor) {
        return executor.get();
    }

    @Override
    public FunctionContext executeWithNoTx(Supplier<FunctionContext> executor) {
        return executor.get();
    }
```