### PR TITLE
filter indexAfterSaveEnabled: false

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=entity
 profile=dev
 
-version=2.2.58
+version=2.2.59
 
 # Build properties
 node_version=12.13.0

--- a/src/main/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexService.java
@@ -12,6 +12,7 @@ import com.icthh.xm.ms.entity.config.ApplicationProperties;
 import com.icthh.xm.ms.entity.config.IndexConfiguration;
 import com.icthh.xm.ms.entity.config.MappingConfiguration;
 import com.icthh.xm.ms.entity.domain.XmEntity;
+import com.icthh.xm.ms.entity.domain.spec.TypeSpec;
 import com.icthh.xm.ms.entity.repository.XmEntityRepositoryInternal;
 import com.icthh.xm.ms.entity.repository.search.XmEntitySearchRepository;
 import lombok.AccessLevel;
@@ -60,6 +61,8 @@ public class ElasticsearchIndexService {
     private static final String XM_ENTITY_FIELD_TYPEKEY = "typeKey";
     private static final String XM_ENTITY_FIELD_ID = "id";
 
+    private final XmEntitySpecService xmEntitySpecService;
+
     private final XmEntityRepositoryInternal xmEntityRepositoryInternal;
     private final XmEntitySearchRepository xmEntitySearchRepository;
     private final ElasticsearchTemplate elasticsearchTemplate;
@@ -86,7 +89,8 @@ public class ElasticsearchIndexService {
                                      IndexConfiguration indexConfiguration,
                                      @Qualifier("taskExecutor") Executor executor,
                                      EntityManager entityManager,
-                                     ApplicationProperties applicationProperties) {
+                                     ApplicationProperties applicationProperties,
+                                     XmEntitySpecService xmEntitySpecService) {
         this.xmEntityRepositoryInternal = xmEntityRepositoryInternal;
         this.xmEntitySearchRepository = xmEntitySearchRepository;
         this.elasticsearchTemplate = elasticsearchTemplate;
@@ -96,6 +100,7 @@ public class ElasticsearchIndexService {
         this.executor = executor;
         this.entityManager = entityManager;
         this.elasticBatchSize = applicationProperties.getElasticBatchSize() != null ? applicationProperties.getElasticBatchSize() : PAGE_SIZE;
+        this.xmEntitySpecService = xmEntitySpecService;
     }
 
     /**
@@ -227,7 +232,21 @@ public class ElasticsearchIndexService {
 
     private Long reindexXmEntity() {
 
-        return reindexXmEntity(null);
+        //get all types that not should be added to elastic
+        Set<String> notAllowedTypes = xmEntitySpecService.findAllTypes().stream()
+            .filter(spec -> Boolean.FALSE.equals(spec.getIndexAfterSaveEnabled()))
+            .map(TypeSpec::getKey)
+            .collect(Collectors.toSet());
+
+        Specification<XmEntity> spec = null;
+
+        if (!notAllowedTypes.isEmpty()) {
+            //exclude removed types from
+            spec = (Specification) (root, query, criteriaBuilder) -> criteriaBuilder.not(
+                root.get(XM_ENTITY_FIELD_TYPEKEY).in(notAllowedTypes));
+        }
+
+        return reindexXmEntity(spec);
     }
 
     private long reindexXmEntity(@Nullable Specification<XmEntity> spec) {

--- a/src/main/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexService.java
@@ -238,12 +238,18 @@ public class ElasticsearchIndexService {
             .map(TypeSpec::getKey)
             .collect(Collectors.toSet());
 
-        Specification<XmEntity> spec = null;
+        //we should sort
+        Specification spec = (root, query, criteriaBuilder) -> {
+            query.orderBy(criteriaBuilder.desc(root.get("id")));
+            return null;
+        };
 
         if (!notAllowedTypes.isEmpty()) {
-            //exclude removed types from
-            spec = (Specification) (root, query, criteriaBuilder) -> criteriaBuilder.not(
-                root.get(XM_ENTITY_FIELD_TYPEKEY).in(notAllowedTypes));
+            log.debug("Types {} should be excluded from reindex", notAllowedTypes);
+            spec = (root, query, criteriaBuilder) -> {
+                query.orderBy(criteriaBuilder.desc(root.get("id")));
+                return criteriaBuilder.not(root.get(XM_ENTITY_FIELD_TYPEKEY).in(notAllowedTypes));
+            };
         }
 
         return reindexXmEntity(spec);

--- a/src/test/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexServiceUnitTest.java
@@ -19,12 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
@@ -56,12 +53,16 @@ public class ElasticsearchIndexServiceUnitTest extends AbstractUnitTest {
     @Mock
     IndexConfiguration indexConfiguration;
 
+    @Mock
+    XmEntitySpecService xmEntitySpecService;
+
     @Before
     public void before() {
         MockitoAnnotations.initMocks(this);
         when(applicationProperties.getElasticBatchSize()).thenReturn(100);
         service = new ElasticsearchIndexService(xmEntityRepository, xmEntitySearchRepository, elasticsearchTemplate,
-            tenantContextHolder, mappingConfiguration, indexConfiguration, null, entityManager, applicationProperties);
+            tenantContextHolder, mappingConfiguration, indexConfiguration, null, entityManager, applicationProperties,
+            xmEntitySpecService);
         service.setSelfReference(service);
     }
 

--- a/src/test/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/ElasticsearchIndexServiceUnitTest.java
@@ -1,7 +1,8 @@
 package com.icthh.xm.ms.entity.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -78,8 +79,8 @@ public class ElasticsearchIndexServiceUnitTest extends AbstractUnitTest {
     @SneakyThrows
     private void prepareInternal() {
         Class<XmEntity> entityClass = XmEntity.class;
-        when(xmEntityRepository.count(null)).thenReturn(10L);
-        when(xmEntityRepository.findAll(null, PageRequest.of(0, 100))).thenReturn(
+        when(xmEntityRepository.count(notNull())).thenReturn(10L);
+        when(xmEntityRepository.findAll(notNull(), eq(PageRequest.of(0, 100)))).thenReturn(
             new PageImpl<>(Collections.singletonList(createObject(entityClass))));
     }
 
@@ -93,7 +94,7 @@ public class ElasticsearchIndexServiceUnitTest extends AbstractUnitTest {
         verify(elasticsearchTemplate).createIndex(entityClass);
         verify(elasticsearchTemplate).putMapping(entityClass);
 
-        verify(xmEntityRepository, times(4)).count(any());
+        verify(xmEntityRepository, times(4)).count(notNull());
 
         ArgumentCaptor<List> list = ArgumentCaptor.forClass(List.class);
         verify(xmEntitySearchRepository).saveAll(list.capture());

--- a/src/test/resources/config/specs/xmentityspec-resinttest.yml
+++ b/src/test/resources/config/specs/xmentityspec-resinttest.yml
@@ -666,3 +666,8 @@ types:
         - key: TEST_NO_PROCESSING_REFS_LINK_KEY
           builderType: NEW
           typeKey: TEST_NO_PROCESSING_REFS
+    - key: ACCOUNT.NO_ELASTIC_SAVE
+      name: { en: "TEST_NO_ELASTIC_SAVE" }
+      isApp: false
+      isAbstract: false
+      indexAfterSaveEnabled: false


### PR DESCRIPTION
When Spec has `indexAfterSaveEnabled: false`
reindexAll should not select this types for Elastic insert