### PR TITLE
Improme s3 tests ports

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=entity
 profile=dev
 
-version=5.0.7
+version=5.0.8
 
 
 # Build properties

--- a/src/test/java/com/icthh/xm/ms/entity/config/amazon/AmazonS3TemplateUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/config/amazon/AmazonS3TemplateUnitTest.java
@@ -6,10 +6,6 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.Region;
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 import com.icthh.xm.ms.entity.AbstractJupiterUnitTest;
 import com.icthh.xm.ms.entity.config.ApplicationProperties;
 
@@ -18,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.function.Consumer;
 
 import com.icthh.xm.ms.entity.domain.Attachment;
 import com.icthh.xm.ms.entity.domain.Content;
@@ -49,13 +44,7 @@ public class AmazonS3TemplateUnitTest extends AbstractJupiterUnitTest {
 
     @Container
     public static GenericContainer mockS3 = new GenericContainer("adobe/s3mock")
-        .withCreateContainerCmdModifier(getContainerModifier()).withExposedPorts(9090);;
-
-    private static Consumer<CreateContainerCmd> getContainerModifier() {
-        return containerCmd -> containerCmd
-            .withPortBindings(new PortBinding(Ports.Binding.bindPort(9191), new ExposedPort(9191)))
-            .withPortBindings(new PortBinding(Ports.Binding.bindPort(9090), new ExposedPort(9090)));
-    }
+        .withExposedPorts(9090);
 
     public AmazonS3 createS3Client() {
         final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
@@ -65,7 +54,7 @@ public class AmazonS3TemplateUnitTest extends AbstractJupiterUnitTest {
                                     .enablePathStyleAccess()
                                     .withEndpointConfiguration(
                                         new AwsClientBuilder.EndpointConfiguration(
-                                            "http://127.0.0.1:9090",
+                                            "http://" + mockS3.getHost() + ":" + mockS3.getMappedPort(9090),
                                             Region.US_Standard.getFirstRegionId()
                                         )).build();
     }

--- a/src/test/java/com/icthh/xm/ms/entity/repository/backend/S3StorageRepositoryIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/repository/backend/S3StorageRepositoryIntTest.java
@@ -6,10 +6,6 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.Region;
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 import com.icthh.xm.commons.security.XmAuthenticationContextHolder;
 import com.icthh.xm.commons.tenant.TenantContextHolder;
 import com.icthh.xm.commons.tenant.TenantContextUtils;
@@ -42,7 +38,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static com.icthh.xm.commons.lep.XmLepConstants.THREAD_CONTEXT_KEY_AUTH_CONTEXT;
 import static com.icthh.xm.commons.lep.XmLepConstants.THREAD_CONTEXT_KEY_TENANT_CONTEXT;
@@ -67,14 +62,7 @@ public class S3StorageRepositoryIntTest extends AbstractJupiterSpringBootTest {
 
     @Container
     public static GenericContainer<?> mockS3 = new GenericContainer<>("adobe/s3mock")
-        .withCreateContainerCmdModifier(getContainerModifier())
         .withExposedPorts(9090);
-
-    private static Consumer<CreateContainerCmd> getContainerModifier() {
-        return containerCmd -> containerCmd
-            .withPortBindings(new PortBinding(Ports.Binding.bindPort(9191), new ExposedPort(9191)))
-            .withPortBindings(new PortBinding(Ports.Binding.bindPort(9090), new ExposedPort(9090)));
-    }
 
     public AmazonS3 createS3Client() {
         final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
@@ -84,7 +72,7 @@ public class S3StorageRepositoryIntTest extends AbstractJupiterSpringBootTest {
             .enablePathStyleAccess()
             .withEndpointConfiguration(
                 new AwsClientBuilder.EndpointConfiguration(
-                    "http://127.0.0.1:9090",
+                    "http://" + mockS3.getHost() + ":" + mockS3.getMappedPort(9090),
                     Region.US_Standard.getFirstRegionId()
                 )).build();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 5.0.8
  * Simplified S3 integration test configuration to use dynamic port mapping, improving test reliability and compatibility across different environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->