### PR TITLE
Off otlp default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -87,7 +87,7 @@ apacheTikaVersion=3.2.3
 ## XM custom properties
 lombok_version=1.18.42
 
-xm_commons_version=5.0.18
+xm_commons_version=5.0.19
 
 
 squiggly_filter_version=1.3.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=entity
 profile=dev
 
-version=5.0.9
+version=5.0.10
 
 
 # Build properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -87,7 +87,7 @@ apacheTikaVersion=3.2.3
 ## XM custom properties
 lombok_version=1.18.42
 
-xm_commons_version=5.0.17
+xm_commons_version=5.0.18
 
 
 squiggly_filter_version=1.3.18

--- a/src/main/java/com/icthh/xm/ms/entity/domain/ext/IdOrKeyBeanInfo.java
+++ b/src/main/java/com/icthh/xm/ms/entity/domain/ext/IdOrKeyBeanInfo.java
@@ -1,0 +1,29 @@
+package com.icthh.xm.ms.entity.domain.ext;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.beans.SimpleBeanInfo;
+
+public class IdOrKeyBeanInfo extends SimpleBeanInfo {
+
+    @Override
+    public PropertyDescriptor[] getPropertyDescriptors() {
+        try {
+            // 1. Force the 'key' property to strictly map to getKey(), with NO setter (null)
+            PropertyDescriptor keyProp = new PropertyDescriptor("key", IdOrKey.class, "getKey", null);
+
+            // 2. Map the 'id' property so idOrKey.id still works
+            PropertyDescriptor idProp = new PropertyDescriptor("id", IdOrKey.class, "getId", null);
+
+            // 3. Map 'self' so idOrKey.self works (maps to isSelf())
+            PropertyDescriptor selfProp = new PropertyDescriptor("self", IdOrKey.class, "isSelf", null);
+
+            // Return only the properties we want Groovy/Java to recognize via dot-notation
+            return new PropertyDescriptor[] { keyProp, idProp, selfProp };
+
+        } catch (IntrospectionException e) {
+            // If something goes wrong, fallback to default behavior
+            return super.getPropertyDescriptors();
+        }
+    }
+}

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -13,13 +13,6 @@
 # http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
 # ===================================================================
 management:
-    tracing:
-        export:
-            enabled: false
-    otlp:
-        metrics:
-            export:
-                enabled: false
 logging:
     level:
         ROOT: INFO

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -15,6 +15,13 @@
 # ===================================================================
 
 management:
+    tracing:
+        export:
+            enabled: ${MANAGEMENT_TRACING_EXPORT_ENABLED:false}
+    otlp:
+        metrics:
+            export:
+                enabled: ${MANAGEMENT_OTLP_METRICS_EXPORT_ENABLED:false}
     endpoints:
         web:
             base-path: /management


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable observability toggles for tracing export and OTLP metrics (env vars, default false).
  * Stabilized external representation of IdOrKey objects by exposing only key, id and self properties.

* **Chores**
  * Bumped application version to 5.0.10.
  * Removed explicit tracing/metrics disables from the development profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->