### PR TITLE
Add flag to ignore warning mapstruct in compile java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -495,6 +495,7 @@ compileJava {
     dependsOn processResources
     // add method parameters names to .class (used by LEP scripts)
     options.compilerArgs << '-parameters'
+    options.compilerArgs << '-Amapstruct.unmappedTargetPolicy=IGNORE'
 }
 processResources.dependsOn cleanResources, bootBuildInfo
 bootBuildInfo.mustRunAfter cleanResources

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=entity
 profile=dev
 
-version=5.0.11
+version=5.0.12
 
 
 # Build properties


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration to adjust Java compilation/annotation processing behavior.
  * Bumped the project version from 5.0.11 to 5.0.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->