### PR TITLE
skip empty collections

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=entity
 profile=dev
 
-version=5.0.12
+version=5.0.13
 
 
 # Build properties

--- a/src/main/java/com/icthh/xm/ms/entity/config/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/ms/entity/config/ApplicationProperties.java
@@ -132,6 +132,8 @@ public class ApplicationProperties {
         private String lepResourcePathPattern;
         private Boolean warmupScripts;
         private List<String> tenantsWithLepWarmup;
+        private Boolean precompiledMode;
+        private String pathToWorkingDirectory;
     }
 
     @Getter

--- a/src/main/java/com/icthh/xm/ms/entity/domain/serializer/NewSimpleLinkSerializer.java
+++ b/src/main/java/com/icthh/xm/ms/entity/domain/serializer/NewSimpleLinkSerializer.java
@@ -61,7 +61,10 @@ public class NewSimpleLinkSerializer extends StdSerializer<Link> {
             write(jsonGenerator, provider, "description", value.getTarget().getDescription());
             write(jsonGenerator, provider, "createdBy", value.getTarget().getCreatedBy());
             write(jsonGenerator, provider, "removed", value.getTarget().isRemoved());
-            write(jsonGenerator, provider, "data", value.getTarget().getData());
+            // skip empty data to match non_empty inclusion of the DTO serialization path
+            if (value.getTarget().getData() != null && !value.getTarget().getData().isEmpty()) {
+                write(jsonGenerator, provider, "data", value.getTarget().getData());
+            }
             jsonGenerator.writeEndObject();
         } else {
             jsonGenerator.writeNullProperty("target");

--- a/src/main/java/com/icthh/xm/ms/entity/domain/serializer/SimpleLinkSerializer.java
+++ b/src/main/java/com/icthh/xm/ms/entity/domain/serializer/SimpleLinkSerializer.java
@@ -62,7 +62,10 @@ public class SimpleLinkSerializer extends StdSerializer<Link> {
             write(jsonGenerator, provider, "description", value.getTarget().getDescription());
             write(jsonGenerator, provider, "createdBy", value.getTarget().getCreatedBy());
             write(jsonGenerator, provider, "removed", value.getTarget().isRemoved());
-            write(jsonGenerator, provider, "data", value.getTarget().getData());
+            // skip empty data to match non_empty inclusion of the DTO serialization path
+            if (value.getTarget().getData() != null && !value.getTarget().getData().isEmpty()) {
+                write(jsonGenerator, provider, "data", value.getTarget().getData());
+            }
         }
         jsonGenerator.writeEndObject();
 

--- a/src/main/java/com/icthh/xm/ms/entity/service/dto/CalendarDto.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/dto/CalendarDto.java
@@ -44,7 +44,7 @@ public class CalendarDto implements Serializable {
     @ApiModelProperty(value = "End date")
     private Instant endDate;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<EventDto> events = new HashSet<>();
 
     @NotNull

--- a/src/main/java/com/icthh/xm/ms/entity/service/dto/XmEntityDto.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/dto/XmEntityDto.java
@@ -87,35 +87,35 @@ public class XmEntityDto implements Serializable, WithId, WithTypeKey, EntityBas
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer version;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<AttachmentDto> attachments = new HashSet<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<CalendarDto> calendars = new HashSet<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<LocationDto> locations = new HashSet<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<RatingDto> ratings = new HashSet<>();
 
     @Valid
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<TagDto> tags = new HashSet<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<CommentDto> comments = new HashSet<>();
 
     @JsonIgnore
     private Set<VoteDto> votes = new HashSet<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<LinkDto> sources = new HashSet<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<LinkDto> targets = new HashSet<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<FunctionContextDto> functionContexts = new HashSet<>();
 
     @JsonIgnore

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -18,8 +18,8 @@ logging:
         ROOT: INFO
         io.github.jhipster: INFO
         com.icthh.xm: DEBUG
-        com.fasterxml.jackson: DEBUG
-        org.springframework.web: DEBUG
+        com.fasterxml.jackson: INFO
+        org.springframework.web: INFO
 spring:
     devtools:
         restart:

--- a/src/test/java/com/icthh/xm/ms/entity/domain/XmEntityDtoJsonSerializationIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/domain/XmEntityDtoJsonSerializationIntTest.java
@@ -173,7 +173,7 @@ public class XmEntityDtoJsonSerializationIntTest extends AbstractJupiterSpringBo
     // ==================== GROUP 1: Serialization - Scalar Fields ====================
 
     @Test
-    void serialize_minimalEntity_emptyCollectionsPresent() throws Exception {
+    void serialize_minimalEntity_emptyCollectionsOmitted() throws Exception {
         XmEntity entity = createMinimalEntity();
         entity.setData(new HashMap<>());
 
@@ -186,17 +186,17 @@ public class XmEntityDtoJsonSerializationIntTest extends AbstractJupiterSpringBo
         assertThat(json.has("startDate")).isTrue();
         assertThat(json.has("updateDate")).isTrue();
 
-        // Empty collections present as empty arrays
-        assertThat(json.get("tags").isArray()).isTrue();
-        assertThat(json.get("tags").size()).isEqualTo(0);
-        assertThat(json.get("locations").isArray()).isTrue();
-        assertThat(json.get("locations").size()).isEqualTo(0);
-        assertThat(json.get("attachments").isArray()).isTrue();
-        assertThat(json.get("comments").isArray()).isTrue();
-        assertThat(json.get("ratings").isArray()).isTrue();
-        assertThat(json.get("calendars").isArray()).isTrue();
-        assertThat(json.get("functionContexts").isArray()).isTrue();
-        assertThat(json.get("targets").isArray()).isTrue();
+        // Empty collections are omitted (same as pre-DTO behavior with
+        // spring.jackson.default-property-inclusion=non_empty)
+        assertThat(json.has("tags")).isFalse();
+        assertThat(json.has("locations")).isFalse();
+        assertThat(json.has("attachments")).isFalse();
+        assertThat(json.has("comments")).isFalse();
+        assertThat(json.has("ratings")).isFalse();
+        assertThat(json.has("calendars")).isFalse();
+        assertThat(json.has("functionContexts")).isFalse();
+        assertThat(json.has("targets")).isFalse();
+        assertThat(json.has("sources")).isFalse();
 
         // Empty data map present
         assertThat(json.has("data")).isTrue();

--- a/src/test/java/com/icthh/xm/ms/entity/web/rest/TestUtil.java
+++ b/src/test/java/com/icthh/xm/ms/entity/web/rest/TestUtil.java
@@ -74,8 +74,9 @@ public class TestUtil {
         return JsonMapper.builder()
                 .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
                 .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+                // mirrors production spring.jackson.default-property-inclusion=non_empty
                 .changeDefaultPropertyInclusion(incl ->
-                        incl.withValueInclusion(JsonInclude.Include.NON_NULL)
+                        incl.withValueInclusion(JsonInclude.Include.NON_EMPTY)
                 )
                 .disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
                 .build();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty collections are now omitted from JSON responses instead of being returned as empty arrays in several entity-related payloads.
  * Calendar events are no longer included when there are none.
  * Link-related responses now skip empty target data fields.

* **Chores**
  * Updated the application version to **5.0.13**.
  * Adjusted development logging verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->