### PR TITLE
FIX: migrate org.hibernate.jpa.QueryHints.SPEC_HINT_TIMEOUT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=entity
 profile=dev
 
-version=5.0.27
+version=5.0.28
 
 
 # Build properties

--- a/src/main/java/com/icthh/xm/ms/entity/repository/impl/XmEntityRepositoryInternalImpl.java
+++ b/src/main/java/com/icthh/xm/ms/entity/repository/impl/XmEntityRepositoryInternalImpl.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
@@ -40,7 +41,7 @@ import org.springframework.stereotype.Component;
 
 import static java.util.Collections.emptyList;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
-import static org.hibernate.jpa.QueryHints.SPEC_HINT_TIMEOUT;
+import static org.hibernate.jpa.AvailableHints.HINT_SPEC_QUERY_TIMEOUT;
 
 @Slf4j
 @Component
@@ -55,6 +56,7 @@ public class XmEntityRepositoryInternalImpl implements XmEntityRepositoryInterna
 
     @Override
     @Transactional
+    @Nullable
     public XmEntity findOneByIdForUpdate(Long id) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<XmEntity> criteriaQuery = builder.createQuery(XmEntity.class);
@@ -64,13 +66,13 @@ public class XmEntityRepositoryInternalImpl implements XmEntityRepositoryInterna
         TypedQuery<XmEntity> query = entityManager
             .createQuery(criteriaQuery)
             .setLockMode(LockModeType.PESSIMISTIC_WRITE)
-            .setHint(SPEC_HINT_TIMEOUT, applicationProperties.getJpa().getFindOneByIdForUpdateTimeout());
+            .setHint(HINT_SPEC_QUERY_TIMEOUT, applicationProperties.getJpa().getFindOneByIdForUpdateTimeout());
 
         List<XmEntity> resultList = query.getResultList();
         if (isEmpty(resultList)) {
             return null;
         }
-        return resultList.get(0);
+        return resultList.getFirst();
     }
 
     /**


### PR DESCRIPTION
HHH90000021: Encountered deprecated setting [javax.persistence.query.timeout], use [jakarta.persistence.query.timeout] instead

FIX: migrate org.hibernate.jpa.QueryHints.SPEC_HINT_TIMEOUT to org.hi…bernate.jpa.AvailableHints.HINT_SPEC_QUERY_TIMEOUT (removes warning in log)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of entity lookups that use database locking.
  * Preserved safe handling when no matching entity is found.
  * Updated query timeout handling for better compatibility with the persistence layer.

* **Chores**
  * Updated the application version from 5.0.27 to 5.0.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->