### PR TITLE
Fix deleteInBatch into LinkService

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=entity
 profile=dev
 
-version=5.0.28
+version=5.0.29
 
 
 # Build properties

--- a/src/main/java/com/icthh/xm/ms/entity/service/LinkService.java
+++ b/src/main/java/com/icthh/xm/ms/entity/service/LinkService.java
@@ -14,6 +14,7 @@ import com.icthh.xm.ms.entity.repository.LinkRepository;
 import com.icthh.xm.ms.entity.repository.XmEntityRepository;
 import com.icthh.xm.ms.entity.security.access.XmEntityDynamicPermissionCheckService;
 import com.icthh.xm.ms.entity.service.impl.StartUpdateDateGenerationStrategy;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -47,6 +48,8 @@ public class LinkService extends TransactionPropagationService<LinkService> {
     private final XmEntityRepository xmEntityRepository;
 
     private final XmEntityDynamicPermissionCheckService permissionCheckService;
+
+    private final EntityManager entityManager;
 
     /**
      * Save a link.
@@ -85,8 +88,14 @@ public class LinkService extends TransactionPropagationService<LinkService> {
         return linkRepository.saveAll(list);
     }
 
-    public void deleteInBatch(List<Link> list) {
-        linkRepository.deleteInBatch(list);
+    /**
+     * Deletes links using bulk operation and detaches deleted entities
+     * from the persistence context to prevent stale Link entities
+     * from participating in subsequent flush operations.
+     */
+    public void deleteInBatch(List<Link> links) {
+        linkRepository.deleteAllInBatch(links);
+        links.forEach(entityManager::detach);
     }
 
     private Long entityId(XmEntity entity) {

--- a/src/test/java/com/icthh/xm/ms/entity/service/LinkServiceIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/LinkServiceIntTest.java
@@ -8,6 +8,8 @@ import com.icthh.xm.lep.api.LepManager;
 import com.icthh.xm.ms.entity.AbstractJupiterSpringBootTest;
 import com.icthh.xm.ms.entity.domain.Link;
 import com.icthh.xm.ms.entity.domain.Link_;
+import com.icthh.xm.ms.entity.domain.XmEntity;
+import com.icthh.xm.ms.entity.repository.XmEntityRepository;
 import com.icthh.xm.ms.entity.security.access.XmEntityDynamicPermissionCheckService;
 import com.icthh.xm.ms.entity.web.rest.LinkResourceIntTest;
 import jakarta.persistence.EntityManager;
@@ -31,7 +33,11 @@ import java.util.List;
 import static com.icthh.xm.commons.lep.XmLepConstants.THREAD_CONTEXT_KEY_AUTH_CONTEXT;
 import static com.icthh.xm.commons.lep.XmLepConstants.THREAD_CONTEXT_KEY_TENANT_CONTEXT;
 import static com.icthh.xm.ms.entity.security.access.FeatureContext.LINK_DELETE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -52,6 +58,8 @@ public class LinkServiceIntTest extends AbstractJupiterSpringBootTest {
     private XmEntityDynamicPermissionCheckService dynamicPermissionCheckService;
     @Autowired
     private XmAuthenticationContextHolder authContextHolder;
+    @Autowired
+    private XmEntityRepository xmEntityRepository;
 
     private List<Link> expected;
 
@@ -77,7 +85,7 @@ public class LinkServiceIntTest extends AbstractJupiterSpringBootTest {
         Page<Link> actual = linkService.findAll(Specification.where((root, query, criteriaBuilder)
             -> criteriaBuilder.isNotNull(root.get(Link_.id))), PageRequest.of(0, expected.size()));
         Assertions.assertNotNull(actual);
-        Assertions.assertEquals(expected.size(), actual.getContent().size());
+        assertEquals(expected.size(), actual.getContent().size());
         Assertions.assertTrue(actual.getContent().containsAll(expected));
     }
 
@@ -110,6 +118,59 @@ public class LinkServiceIntTest extends AbstractJupiterSpringBootTest {
         });
     }
 
+    @Test
+    @Transactional
+    void deleteInBatchShouldDeleteLinks() {
+        List<Link> linksToDelete = expected.subList(0, 2);
+
+        linkService.deleteInBatch(linksToDelete);
+
+        List<Link> actual = linkService.findAll(
+            Specification.where((root, query, cb) ->
+                cb.isNotNull(root.get(Link_.id))),
+            PageRequest.of(0, expected.size())
+        ).getContent();
+
+        assertEquals(expected.size() - linksToDelete.size(), actual.size());
+        assertFalse(actual.containsAll(linksToDelete));
+    }
+
+    @Test
+    @Transactional
+    void deleteInBatchShouldDetachDeletedLinks() {
+        Link linkToDelete = expected.getFirst();
+        XmEntity targetToDelete = linkToDelete.getTarget();
+
+        assertTrue(em.contains(linkToDelete));
+        assertTrue(em.contains(targetToDelete));
+
+        linkService.deleteInBatch(List.of(linkToDelete));
+
+        assertFalse(em.contains(linkToDelete));
+
+        xmEntityRepository.deleteAll(List.of(targetToDelete));
+
+        assertDoesNotThrow(() -> em.flush());
+    }
+
+    @Test
+    @Transactional
+    void deleteInBatchShouldNotFailOnNextQueryAfterTargetDeletion() {
+        Link linkToDelete = expected.getFirst();
+        XmEntity targetToDelete = linkToDelete.getTarget();
+
+        linkService.deleteInBatch(List.of(linkToDelete));
+
+        xmEntityRepository.deleteAll(List.of(targetToDelete));
+
+        assertDoesNotThrow(() ->
+            linkService.findAll(
+                Specification.where((root, query, cb) ->
+                    cb.isNotNull(root.get(Link_.id))),
+                PageRequest.of(0, 10)
+            )
+        );
+    }
 
     @BeforeTransaction
     public void beforeTransaction() {

--- a/src/test/java/com/icthh/xm/ms/entity/service/LinkServiceIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/service/LinkServiceIntTest.java
@@ -132,7 +132,7 @@ public class LinkServiceIntTest extends AbstractJupiterSpringBootTest {
         ).getContent();
 
         assertEquals(expected.size() - linksToDelete.size(), actual.size());
-        assertFalse(actual.containsAll(linksToDelete));
+        assertTrue(actual.stream().noneMatch(linksToDelete::contains));
     }
 
     @Test

--- a/src/test/java/com/icthh/xm/ms/entity/web/rest/LinkResourceExtendedIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/web/rest/LinkResourceExtendedIntTest.java
@@ -96,6 +96,8 @@ public class LinkResourceExtendedIntTest extends AbstractJupiterSpringBootTest {
     @Autowired
     private JsonMapper jsonMapper;
 
+    @Autowired
+    private EntityManager entityManager;
 
     @Spy
     private StartUpdateDateGenerationStrategy startUpdateDateGenerationStrategy;
@@ -122,7 +124,8 @@ public class LinkResourceExtendedIntTest extends AbstractJupiterSpringBootTest {
             permittedRepository,
             startUpdateDateGenerationStrategy,
             xmEntityRepository,
-            dynamicPermissionCheckService);
+            dynamicPermissionCheckService,
+            entityManager);
 
         linkService.setSelf(linkService);
 

--- a/src/test/java/com/icthh/xm/ms/entity/web/rest/LinkResourceIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/entity/web/rest/LinkResourceIntTest.java
@@ -129,6 +129,9 @@ public class LinkResourceIntTest extends AbstractJupiterSpringBootTest {
     @Autowired
     private JsonMapper jsonMapper;
 
+    @Autowired
+    private EntityManager entityManager;
+
     @BeforeTransaction
     public void beforeTransaction() {
         TenantContextUtils.setTenant(tenantContextHolder, "RESINTTEST");
@@ -149,7 +152,8 @@ public class LinkResourceIntTest extends AbstractJupiterSpringBootTest {
                                       permittedRepository,
                                       startUpdateDateGenerationStrategy,
                                       xmEntityRepository,
-                                      dynamicPermissionCheckService);
+                                      dynamicPermissionCheckService,
+                                      entityManager);
         linkService.setSelf(linkService);
 
         LinkResource linkResourceMock = new LinkResource(linkFacade);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch link deletion to reliably remove links and prevent stale records from remaining in active data.
  * Enhanced deletion handling for linked targets, supporting safer follow-up operations and queries after links are removed.

* **Tests**
  * Added coverage for batch deletion, persistence consistency, linked-target cleanup, and subsequent data retrieval.

* **Release**
  * Updated the project version to 5.0.29.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->